### PR TITLE
Fix: Handle array response in inferenceResultsDecoded

### DIFF
--- a/index.html
+++ b/index.html
@@ -2823,7 +2823,7 @@ Hello, this is a brand 🍉 NEW test message from a regular user!</textarea>
             }" alt="Input Image" style="max-width: 100%; max-height: 400px;">
             <p>Question: ${request.inputFields.question}</p>
             <p>Answer:</p>
-            <github-md>${JSON.parse(request.inferenceResultsDecoded)[0]
+            <github-md>${Array.isArray(request.inferenceResultsDecoded) ? JSON.parse(request.inferenceResultsDecoded)[0] : JSON.parse(request.inferenceResultsDecoded)
             }</github-md>
           `;
         } else if (request.selectedInferenceType === "embedding_document") {


### PR DESCRIPTION
## Changes Made
- Modified the code to check if `request.inferenceResultsDecoded` is an array
- If it's an array, we access the first element using index [0]
- If it's not an array, we parse it directly 