### PR TITLE
Fix promocode prompts

### DIFF
--- a/index.html
+++ b/index.html
@@ -1281,13 +1281,12 @@ Hello, this is a brand 🍉 NEW test message from a regular user!</textarea>
             console.log("Import details:", result.details);
 
             // Automatically set the passphrase for the newly imported PastelID
-            if (result.details && result.details.pastel_id_pubkey) {
-              const pastelID = result.details.pastel_id_pubkey;
-              const defaultPassphrase = "testpass"; // The known default passphrase for promo packs
-              localStorage.setItem(pastelID, btoa(defaultPassphrase));
-              // We don't need to call setSelectedPastelIDAndPassphrase here as the page will reload
+            if (result.details && result.details.processedPacks.length > 0) {
+              result.details.processedPacks.forEach((pack) => {
+                localStorage.setItem(pack.pub_key, btoa(pack.passphrase))
+              })
             }
-
+            // We don't need to call setSelectedPastelIDAndPassphrase here as the page will reload
             // Update modal to inform user about the upcoming page reload
             updateModal(
               "Import Successful",

--- a/rpc_functions.js
+++ b/rpc_functions.js
@@ -1282,7 +1282,7 @@ function getPastelIDDirectory(network) {
   const homeDir = process.env.HOME;
   let pastelIDDir = "";
   if (network === "mainnet") {
-    pastelIDDir = path.join(homeDir, ".pastel", "pastelkeys");
+    pastelIDDir =  process.platform === "darwin" ?  path.join(os.homedir(), "Library", "Application Support", "Pastel", "pastelkeys"):  path.join(homeDir, ".pastel", "pastelkeys");
   } else if (network === "testnet") {
     pastelIDDir = path.join(homeDir, ".pastel", "testnet3", "pastelkeys");
   } else if (network === "devnet") {

--- a/utility_functions.js
+++ b/utility_functions.js
@@ -1338,6 +1338,7 @@ async function waitForCreditPackConfirmation(txid) {
 
 async function importPromotionalPack(jsonFilePath) {
   logger.info(`Starting import of promotional pack from file: ${jsonFilePath}`);
+  const processedPacks = [];
 
   try {
     // Initialize RPC connection
@@ -1399,6 +1400,12 @@ async function importPromotionalPack(jsonFilePath) {
       logger.info(`Passphrase: ${pack.pastel_id_passphrase}`);
       logger.info(`Credit Pack Ticket: ${JSON.stringify(pack, null, 2)}`);
 
+      // Add the processed pack info to our array
+      processedPacks.push({
+        pub_key: pack.pastel_id_pubkey,
+        passphrase: pack.pastel_id_passphrase
+      });
+
       logger.info(`Pack ${i + 1} processed successfully`);
     }
 
@@ -1456,12 +1463,13 @@ async function importPromotionalPack(jsonFilePath) {
     return {
       success: true,
       message: "Promotional pack(s) imported and verified successfully",
+      processedPacks: processedPacks
     };
   } catch (error) {
     logger.error(`Error importing promotional pack: ${error.message}`);
     return {
       success: false,
-      message: `Failed to import promotional pack: ${error.message}`,
+      message: `Failed to import promotional pack: ${error.message}`
     };
   }
 }


### PR DESCRIPTION
## Changes
- Updated `importPromotionalPack` function to track processed packs, return an array of pastelId and passphrase with success result
- Modified client-side storage of Pastel ID passphrase for Promopacks without prompt.
- Adjusted PastelKey directory path for macOS compatibility
